### PR TITLE
fix:(DOS-1442)Termination of pull transfer process from consumer side not success in real but stated as "TERMINATED"

### DIFF
--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProtocolServiceImpl.java
@@ -212,13 +212,13 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
 
     @NotNull
     private ServiceResult<TransferProcess> suspendedAction(TransferSuspensionMessage message, TransferProcess transferProcess) {
-        if (transferProcess.canBeTerminated()) {
-            if (transferProcess.getType() == PROVIDER) {
-                var suspension = dataFlowManager.suspend(transferProcess);
-                if (suspension.failed()) {
-                    return ServiceResult.conflict("Cannot suspend transfer process %s: %s".formatted(transferProcess.getId(), suspension.getFailureDetail()));
-                }
+        if (transferProcess.getType() == PROVIDER) {
+            var suspension = dataFlowManager.suspend(transferProcess);
+            if (suspension.failed()) {
+                return ServiceResult.conflict("Cannot suspend transfer process %s: %s".formatted(transferProcess.getId(), suspension.getFailureDetail()));
             }
+        }
+        if (transferProcess.canBeTerminated()) {
             var reason = message.getReason().stream().map(Object::toString).collect(joining(", "));
             transferProcess.transitionSuspended(reason);
             transferProcess.protocolMessageReceived(message.getId());

--- a/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProtocolServiceImpl.java
+++ b/core/control-plane/control-plane-aggregate-services/src/main/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProtocolServiceImpl.java
@@ -233,12 +233,12 @@ public class TransferProcessProtocolServiceImpl implements TransferProcessProtoc
     @NotNull
     private ServiceResult<TransferProcess> terminatedAction(TransferTerminationMessage message, TransferProcess transferProcess) {
         if (transferProcess.canBeTerminated()) {
-			if (transferProcess.getType() == PROVIDER) {
-				var termination = dataFlowManager.terminate(transferProcess);
-				if (termination.failed()) {
-					return ServiceResult.conflict("Cannot terminate transfer process %s: %s".formatted(transferProcess.getId(), termination.getFailureDetail()));
-				}
-			}
+            if (transferProcess.getType() == PROVIDER) {
+                var termination = dataFlowManager.terminate(transferProcess);
+                if (termination.failed()) {
+                    return ServiceResult.conflict("Cannot terminate transfer process %s: %s".formatted(transferProcess.getId(), termination.getFailureDetail()));
+                }
+            }
             observable.invokeForEach(l -> l.preTerminated(transferProcess));
             transferProcess.transitionTerminated();
             transferProcess.protocolMessageReceived(message.getId());

--- a/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProtocolServiceImplTest.java
+++ b/core/control-plane/control-plane-aggregate-services/src/test/java/org/eclipse/edc/connector/controlplane/services/transferprocess/TransferProcessProtocolServiceImplTest.java
@@ -822,7 +822,7 @@ class TransferProcessProtocolServiceImplTest {
         }
 
         @Test
-        void provider_shouldTerminateDataFlowAndTransitionToTerminated() {
+        void provider_shouldTerminateDataFlowAndTransitionToDeprovisioning() {
             var participantAgent = participantAgent();
             var tokenRepresentation = tokenRepresentation();
             var message = TransferTerminationMessage.Builder.newInstance()

--- a/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/Participant.java
+++ b/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/Participant.java
@@ -457,11 +457,11 @@ public class Participant {
      *
      * @param id transfer process id.
      */
-    public void suspendTransfer(String id) {
+    public void suspendTransfer(String id, String reason) {
         var requestBodyBuilder = createObjectBuilder()
                 .add(CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE))
                 .add(TYPE, "SuspendTransfer")
-                .add("reason", "any reason");
+                .add("reason", reason);
 
         managementEndpoint.baseRequest()
                 .contentType(JSON)

--- a/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/Participant.java
+++ b/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/Participant.java
@@ -57,9 +57,6 @@ import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
  * Essentially a wrapper around the management API enabling to test interactions with other participants, eg. catalog, transfer...
  */
 public class Participant {
-
-    public static final String CONSUMER = "consumer";
-    public static final String PROVIDER = "provider";
     protected String id;
     protected String name;
     protected Endpoint managementEndpoint;
@@ -460,11 +457,11 @@ public class Participant {
      *
      * @param id transfer process id.
      */
-    public void suspendTransfer(String id, String reason) {
+    public void suspendTransfer(String id) {
         var requestBodyBuilder = createObjectBuilder()
                 .add(CONTEXT, createObjectBuilder().add(VOCAB, EDC_NAMESPACE))
                 .add(TYPE, "SuspendTransfer")
-                .add("reason", reason);
+                .add("reason", "any reason");
 
         managementEndpoint.baseRequest()
                 .contentType(JSON)
@@ -519,11 +516,6 @@ public class Participant {
 
     public void awaitTransferToBeInState(String transferProcessId, TransferProcessStates state) {
         await().atMost(timeout).until(() -> getTransferProcessState(transferProcessId), it -> Objects.equals(it, state.name()));
-    }
-
-    @Override
-    public String toString() {
-        return name;
     }
 
     protected String getContractNegotiationField(String negotiationId, String fieldName) {

--- a/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/Participant.java
+++ b/extensions/control-plane/api/management-api/management-api-test-fixtures/src/testFixtures/java/org/eclipse/edc/connector/controlplane/test/system/utils/Participant.java
@@ -58,6 +58,8 @@ import static org.eclipse.edc.spi.constants.CoreConstants.EDC_NAMESPACE;
  */
 public class Participant {
 
+    public static final String CONSUMER = "consumer";
+    public static final String PROVIDER = "provider";
     protected String id;
     protected String name;
     protected Endpoint managementEndpoint;
@@ -517,6 +519,11 @@ public class Participant {
 
     public void awaitTransferToBeInState(String transferProcessId, TransferProcessStates state) {
         await().atMost(timeout).until(() -> getTransferProcessState(transferProcessId), it -> Objects.equals(it, state.name()));
+    }
+
+    @Override
+    public String toString() {
+        return name;
     }
 
     protected String getContractNegotiationField(String negotiationId, String fieldName) {

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferEndToEndTestBase.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferEndToEndTestBase.java
@@ -15,7 +15,6 @@
 package org.eclipse.edc.test.e2e;
 
 import jakarta.json.JsonObject;
-import org.eclipse.edc.connector.controlplane.test.system.utils.Participant;
 import org.eclipse.edc.spi.security.Vault;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,11 +29,11 @@ import static org.eclipse.edc.junit.testfixtures.TestUtils.getResourceFileConten
 public abstract class TransferEndToEndTestBase {
 
     protected static final TransferEndToEndParticipant CONSUMER = TransferEndToEndParticipant.Builder.newInstance()
-            .name(Participant.CONSUMER)
+            .name("consumer")
             .id("urn:connector:consumer")
             .build();
     protected static final TransferEndToEndParticipant PROVIDER = TransferEndToEndParticipant.Builder.newInstance()
-            .name(Participant.PROVIDER)
+            .name("provider")
             .id("urn:connector:provider")
             .build();
 

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferEndToEndTestBase.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferEndToEndTestBase.java
@@ -15,6 +15,7 @@
 package org.eclipse.edc.test.e2e;
 
 import jakarta.json.JsonObject;
+import org.eclipse.edc.connector.controlplane.test.system.utils.Participant;
 import org.eclipse.edc.spi.security.Vault;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,11 +30,11 @@ import static org.eclipse.edc.junit.testfixtures.TestUtils.getResourceFileConten
 public abstract class TransferEndToEndTestBase {
 
     protected static final TransferEndToEndParticipant CONSUMER = TransferEndToEndParticipant.Builder.newInstance()
-            .name("consumer")
+            .name(Participant.CONSUMER)
             .id("urn:connector:consumer")
             .build();
     protected static final TransferEndToEndParticipant PROVIDER = TransferEndToEndParticipant.Builder.newInstance()
-            .name("provider")
+            .name(Participant.PROVIDER)
             .id("urn:connector:provider")
             .build();
 

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferPullEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferPullEndToEndTest.java
@@ -172,7 +172,7 @@ class TransferPullEndToEndTest {
         @Test
         void suspendAndResumeByConsumer_httpPull_dataTransfer_withEdrCache() {
             var assetId = createResources();
-            var startedTransferContext = assertTransferProcessIsStarted(assetId);
+            var startedTransferContext = startTransferProcess(assetId);
             var edrMessage = assertDataIsAccessible(startedTransferContext.consumerTransferProcessId);
 
             CONSUMER.suspendTransfer(startedTransferContext.consumerTransferProcessId, "any reason");
@@ -191,7 +191,7 @@ class TransferPullEndToEndTest {
         @Test
         void suspendAndResumeByProvider_httpPull_dataTransfer_withEdrCache() {
             var assetId = createResources();
-            var startedTransferContext = assertTransferProcessIsStarted(assetId);
+            var startedTransferContext = startTransferProcess(assetId);
             var edrMessage = assertDataIsAccessible(startedTransferContext.consumerTransferProcessId);
 
             PROVIDER.suspendTransfer(startedTransferContext.providerTransferProcessId, "any reason");
@@ -211,7 +211,7 @@ class TransferPullEndToEndTest {
         @Test
         void terminateByProvider_httpPull_dataTransfer() {
             var assetId = createResources();
-            var startedTransferContext = assertTransferProcessIsStarted(assetId);
+            var startedTransferContext = startTransferProcess(assetId);
             var edrMessage = assertDataIsAccessible(startedTransferContext.consumerTransferProcessId);
 
             PROVIDER.terminateTransfer(startedTransferContext.providerTransferProcessId);
@@ -225,7 +225,7 @@ class TransferPullEndToEndTest {
         @Test
         void terminateByConsumer_httpPull_dataTransfer() {
             var assetId = createResources();
-            var startedTransferContext = assertTransferProcessIsStarted(assetId);
+            var startedTransferContext = startTransferProcess(assetId);
             var edrMessage = assertDataIsAccessible(startedTransferContext.consumerTransferProcessId);
 
             CONSUMER.terminateTransfer(startedTransferContext.consumerTransferProcessId);
@@ -341,7 +341,7 @@ class TransferPullEndToEndTest {
             return assetId;
         }
 
-        private StartedTransferContext assertTransferProcessIsStarted(String assetId){
+        private StartedTransferContext startTransferProcess(String assetId){
             var consumerTransferProcessId = CONSUMER.requestAssetFrom(assetId, PROVIDER)
                     .withTransferType("HttpData-PULL")
                     .execute();

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferPullEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferPullEndToEndTest.java
@@ -377,7 +377,7 @@ class TransferPullEndToEndTest {
             await().atMost(timeout).untilAsserted(() -> assertThatThrownBy(() -> CONSUMER.pullData(startedTransferContext.edr, Map.of("message", startedTransferContext.msg), body -> assertThat(body).isEqualTo("data"))));
         }
 
-        private record StartedTransferContext (String providerTransferProcessId, String consumerTransferProcessId, DataAddress edr, String msg) { }
+        private record StartedTransferContext (String consumerTransferProcessId, String providerTransferProcessId, DataAddress edr, String msg) { }
 
         /**
          * Mocked http provisioner

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferPullEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferPullEndToEndTest.java
@@ -362,6 +362,8 @@ class TransferPullEndToEndTest {
             await().atMost(timeout).untilAsserted(() -> assertThatThrownBy(() -> CONSUMER.pullData(startedTransferContext.edr, Map.of("message", startedTransferContext.msg), body -> assertThat(body).isEqualTo("data"))));
         }
 
+        private record StartedTransferContext (String providerTransferProcessId, String consumerTransferProcessId, DataAddress edr, String msg) { }
+
         /**
          * Mocked http provisioner
          */
@@ -401,7 +403,6 @@ class TransferPullEndToEndTest {
         }
     }
 
-    private record StartedTransferContext (String providerTransferProcessId, String consumerTransferProcessId, DataAddress edr, String msg) { }
 
     @Nested
     @EndToEndTest

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferPullEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferPullEndToEndTest.java
@@ -328,12 +328,11 @@ class TransferPullEndToEndTest {
             var consumerTransferProcessId = CONSUMER.requestAssetFrom(assetId, PROVIDER)
                     .withTransferType("HttpData-PULL")
                     .execute();
+            CONSUMER.awaitTransferToBeInState(consumerTransferProcessId, STARTED);
 
             var providerTransferProcessId  = PROVIDER.getTransferProcesses().stream()
                     .filter(filter -> filter.asJsonObject().getString("correlationId").equals(consumerTransferProcessId))
                     .map(id -> id.asJsonObject().getString("@id")).findFirst().orElseThrow();
-
-            CONSUMER.awaitTransferToBeInState(consumerTransferProcessId, STARTED);
             PROVIDER.awaitTransferToBeInState(providerTransferProcessId, STARTED);
 
             var edrMessage = assertDataIsAccessible(consumerTransferProcessId);

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferStreamingEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferStreamingEndToEndTest.java
@@ -235,7 +235,7 @@ public class TransferStreamingEndToEndTest {
                         .withDestination(kafkaSink()).withTransferType("Kafka-PUSH").execute();
                 assertMessagesAreSentTo(consumer);
 
-                CONSUMER.suspendTransfer(transferProcessId, "any kind of reason");
+                CONSUMER.suspendTransfer(transferProcessId);
                 CONSUMER.awaitTransferToBeInState(transferProcessId, SUSPENDED);
                 assertNoMoreMessagesAreSentTo(consumer);
 

--- a/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferStreamingEndToEndTest.java
+++ b/system-tests/e2e-transfer-test/runner/src/test/java/org/eclipse/edc/test/e2e/TransferStreamingEndToEndTest.java
@@ -235,7 +235,7 @@ public class TransferStreamingEndToEndTest {
                         .withDestination(kafkaSink()).withTransferType("Kafka-PUSH").execute();
                 assertMessagesAreSentTo(consumer);
 
-                CONSUMER.suspendTransfer(transferProcessId);
+                CONSUMER.suspendTransfer(transferProcessId, "any reason");
                 CONSUMER.awaitTransferToBeInState(transferProcessId, SUSPENDED);
                 assertNoMoreMessagesAreSentTo(consumer);
 


### PR DESCRIPTION
What this PR changes/adds
Start termination process from data flow manager for provider when termination initiated by consumer

Why it does that
During the termination of PULL transfer process from consumer, system does not call method terminate() from DataFlowManager on provider side.
As a result process not terminated in real but transfer process had state "TERMINATED", and then it is not possible to initiate terminating process again not from consumer neither form provider side.

Further notes
After provider moved to TERMINATED state, it also should move to the DEPROVISIONING automatically

Linked Issue(s)
Closes [#4637](https://github.com/eclipse-edc/Connector/issues/4592)
Closes [DOS-1442](https://cofinity-x.atlassian.net/browse/DOS-1442)

[DOS-1442]: https://cofinity-x.atlassian.net/browse/DOS-1442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ